### PR TITLE
fixed json compile

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ function run (bundle, mount, cache, opts, filename) {
   if (!src) throw new Error('Module not in bundle: "' + filename + '"')
 
   const parent = new URL(mod.filename, 'file://')
-  compile(mod, b4a.toString(src))
+  const isJson = isJsonSrc(b4a.toString(src))
+  compile(mod, !isJson ? b4a.toString(src) : 'return ' + b4a.toString(src))
 
   return mod.exports
 
@@ -82,4 +83,13 @@ function run (bundle, mount, cache, opts, filename) {
       return null
     }
   }
+}
+
+function isJsonSrc (str) {
+  try {
+    JSON.parse(str)
+  } catch {
+    return false
+  }
+  return true
 }

--- a/test/test.js
+++ b/test/test.js
@@ -48,3 +48,17 @@ test('can load native addons from bundle', function (t) {
     b.write(key, fs.readFileSync(path.join(__dirname, '..', key)))
   }
 })
+
+test('can compile json file', function (t) {
+  const b = new Bundle()
+  const fs = require('fs')
+
+  b.write('/index.js', 'module.exports = require("./package.json")')
+  add('/package.json')
+  const pkg = runBundle(b.toBuffer(), { mount: path.join(__dirname, 'test.bundle') })
+  t.ok(pkg)
+
+  function add (key) {
+    b.write(key, fs.readFileSync(path.join(__dirname, '..', key)))
+  }
+})


### PR DESCRIPTION
Node-bare-bunde is unable to compile JSON files since `new Function('__filename', '__dirname', 'module', 'exports', 'require', __source)` errors in case that `__source` is a well formed `.json` file.

This PR adds fixes the problem by adding `return ` to `__source ` in the case that `__source` is a valid JSON.
